### PR TITLE
feat: polish PasswordGate and NameGate auth screens

### DIFF
--- a/packages/widget/src/client/feedback-panel.tsx
+++ b/packages/widget/src/client/feedback-panel.tsx
@@ -299,11 +299,18 @@ function PasswordGate({ onAuth, onClose, apiUrl }: { onAuth: () => void; onClose
       >
         <X className="h-3.5 w-3.5" />
       </button>
-      <div className="mb-5 flex h-14 w-14 items-center justify-center rounded-full bg-muted">
-        <Lightbulb className="h-6 w-6 text-muted-foreground" />
+
+      <p className="mb-5 text-[10px] font-semibold tracking-widest uppercase" style={{ color: 'rgba(139,141,147,0.5)' }}>
+        feedback
+      </p>
+
+      <div className="feedback-gate-orb mb-5">
+        <Lightbulb className="h-5 w-5" style={{ color: 'rgba(255,255,255,0.65)' }} />
       </div>
+
+      <h2 className="mb-1 text-[15px] font-semibold text-foreground">Welcome.</h2>
       <p className="mb-8 text-center text-sm text-muted-foreground">
-        Share your ideas to improve the app
+        Share your ideas and help us improve.
       </p>
 
       {error && (
@@ -324,7 +331,7 @@ function PasswordGate({ onAuth, onClose, apiUrl }: { onAuth: () => void; onClose
           aria-label="Password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
-          className="h-10 w-full rounded-xl border border-border bg-background px-4 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/20"
+          className="h-10 w-full rounded-xl border border-border bg-background px-4 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
         />
         <button
           type="submit"
@@ -365,12 +372,20 @@ function NameGate({ onName, onClose }: { onName: (name: string) => void; onClose
       >
         <X className="h-3.5 w-3.5" />
       </button>
-      <div className="mb-5 flex h-14 w-14 items-center justify-center rounded-full bg-muted">
-        <Lightbulb className="h-6 w-6 text-muted-foreground" />
-      </div>
-      <p className="mb-8 text-center text-sm text-muted-foreground">
-        What should we call you?
+
+      <p className="mb-5 text-[10px] font-semibold tracking-widest uppercase" style={{ color: 'rgba(139,141,147,0.5)' }}>
+        feedback
       </p>
+
+      <div className="feedback-gate-orb mb-5">
+        <Lightbulb className="h-5 w-5" style={{ color: 'rgba(255,255,255,0.65)' }} />
+      </div>
+
+      <h2 className="mb-1 text-[15px] font-semibold text-foreground">What should we call you?</h2>
+      <p className="mb-8 text-center text-sm text-muted-foreground">
+        We'll use your name to identify your feedback.
+      </p>
+
       <form onSubmit={handleSubmit} className="w-full space-y-3">
         <input
           type="text"
@@ -379,7 +394,7 @@ function NameGate({ onName, onClose }: { onName: (name: string) => void; onClose
           aria-label="Your name"
           value={name}
           onChange={(e) => setName(e.target.value)}
-          className="h-10 w-full rounded-xl border border-border bg-background px-4 text-sm text-foreground placeholder:text-muted-foreground focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/20"
+          className="h-10 w-full rounded-xl border border-border bg-background px-4 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
         />
         <button
           type="submit"

--- a/packages/widget/src/client/styles.css
+++ b/packages/widget/src/client/styles.css
@@ -286,6 +286,61 @@
   border-radius: 0.75rem;
 }
 
+/* ── Gate screens — branded orb ── */
+.feedback-gate-orb {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 3.5rem;
+  height: 3.5rem;
+  border-radius: 50%;
+  background: radial-gradient(circle at center, rgba(94, 158, 255, 0.14) 0%, rgba(255, 255, 255, 0.05) 60%, transparent 100%);
+  border: 1px solid rgba(255, 255, 255, 0.10);
+  animation: feedback-orb-pulse 3s ease-in-out infinite;
+}
+.feedback-gate-orb::before {
+  content: '';
+  position: absolute;
+  inset: -5px;
+  border-radius: 50%;
+  border: 1px solid rgba(94, 158, 255, 0.12);
+  animation: feedback-ring-pulse 3s ease-in-out infinite;
+  pointer-events: none;
+}
+@keyframes feedback-orb-pulse {
+  0%, 100% {
+    background: radial-gradient(circle at center, rgba(94, 158, 255, 0.12) 0%, rgba(255, 255, 255, 0.04) 60%, transparent 100%);
+    border-color: rgba(255, 255, 255, 0.10);
+  }
+  50% {
+    background: radial-gradient(circle at center, rgba(94, 158, 255, 0.20) 0%, rgba(255, 255, 255, 0.07) 60%, transparent 100%);
+    border-color: rgba(94, 158, 255, 0.22);
+  }
+}
+@keyframes feedback-ring-pulse {
+  0%, 100% { opacity: 0.4; transform: scale(1); }
+  50% { opacity: 0.85; transform: scale(1.06); }
+}
+
+/* ── Gate screens — input glassmorphism overrides ── */
+.feedback-panel input[type="password"],
+.feedback-panel input[type="text"] {
+  background: rgba(255, 255, 255, 0.06) !important;
+  border-color: rgba(255, 255, 255, 0.10) !important;
+  color: #e8eaed !important;
+}
+.feedback-panel input[type="password"]::placeholder,
+.feedback-panel input[type="text"]::placeholder {
+  color: rgba(139, 141, 147, 0.8);
+}
+.feedback-panel input[type="password"]:focus,
+.feedback-panel input[type="text"]:focus {
+  border-color: rgba(255, 255, 255, 0.20) !important;
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(94, 158, 255, 0.08);
+}
+
 /* ── Scrollbar — hidden + scroll isolation ── */
 .feedback-panel * {
   scrollbar-width: none;


### PR DESCRIPTION
## Summary

- Replace plain `bg-muted` circles with a pulsing gradient orb (CSS animation with subtle blue glow) for a distinctive branded element
- Add a "feedback" micro-wordmark above the orb on both gate screens
- Improve headline copy: "Welcome." + "Share your ideas and help us improve." (PasswordGate) and "What should we call you?" + "We'll use your name to identify your feedback." (NameGate)
- Override `border-border bg-background` shadcn classes for inputs with explicit glassmorphism CSS (`rgba(255,255,255,0.06)` background, matching border + focus ring), consistent with the rest of the panel

## Test plan

- [ ] Open the widget for the first time (clear sessionStorage) — PasswordGate should show branded orb, wordmark, improved copy, and glass-styled input
- [ ] Submit a name — NameGate should have consistent styling with PasswordGate
- [ ] After auth, the chat thread UI should look unchanged
- [ ] Input focus ring and hover states look correct in dark glassmorphism panel

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added decorative animated orb element to feedback gate screens.

* **Style**
  * Enhanced input styling with improved focus effects and glassmorphism design.
  * Updated gate screen layout with feedback-oriented messaging and improved visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->