### PR TITLE
feat: animated pipeline explainer for empty state

### DIFF
--- a/packages/dashboard/src/app/globals.css
+++ b/packages/dashboard/src/app/globals.css
@@ -201,6 +201,35 @@ select.input-field {
 .flow-dot:nth-child(2) { animation-delay: 0.66s; }
 .flow-dot:nth-child(3) { animation-delay: 1.33s; }
 
+/* ── Pipeline explainer stage pulse ── */
+@keyframes pipeline-stage-pulse {
+  0% {
+    border-color: rgba(255, 255, 255, 0.07);
+    background: rgba(255, 255, 255, 0.03);
+    box-shadow: none;
+  }
+  8% {
+    border-color: rgba(94, 158, 255, 0.45);
+    background: rgba(94, 158, 255, 0.07);
+    box-shadow: 0 0 18px rgba(94, 158, 255, 0.18);
+  }
+  18% {
+    border-color: rgba(94, 158, 255, 0.45);
+    background: rgba(94, 158, 255, 0.07);
+    box-shadow: 0 0 18px rgba(94, 158, 255, 0.18);
+  }
+  30% {
+    border-color: rgba(255, 255, 255, 0.07);
+    background: rgba(255, 255, 255, 0.03);
+    box-shadow: none;
+  }
+  100% {
+    border-color: rgba(255, 255, 255, 0.07);
+    background: rgba(255, 255, 255, 0.03);
+    box-shadow: none;
+  }
+}
+
 /* ── Slide-over backdrop ── */
 .slide-over-backdrop {
   position: fixed;

--- a/packages/dashboard/src/app/projects/[id]/page.tsx
+++ b/packages/dashboard/src/app/projects/[id]/page.tsx
@@ -7,6 +7,7 @@ import { RunsTable } from '@/components/runs-table'
 import { Github, Sparkles, Lightbulb, MessageSquare, ArrowRight } from 'lucide-react'
 import { DeleteProjectButton } from '@/components/delete-project-button'
 import { ProposalsCard } from '@/components/proposals-card'
+import { PipelineExplainer } from '@/components/pipeline-explainer'
 
 export default async function ProjectPage({
   params,
@@ -134,6 +135,13 @@ export default async function ProjectPage({
           </div>
         )
       })()}
+
+      {/* Pipeline explainer (shown when no runs yet) */}
+      {(runs ?? []).length === 0 && (
+        <div className="mb-8">
+          <PipelineExplainer />
+        </div>
+      )}
 
       {/* Runs table */}
       <div className="mb-8">

--- a/packages/dashboard/src/components/pipeline-explainer.tsx
+++ b/packages/dashboard/src/components/pipeline-explainer.tsx
@@ -1,0 +1,86 @@
+const STAGES = [
+  { icon: '💬', label: 'Chat', desc: 'User shares an idea via the widget' },
+  { icon: '📋', label: 'Issue', desc: 'AI refines it into a GitHub issue' },
+  { icon: '🤖', label: 'Agent', desc: 'Claude implements the change' },
+  { icon: '✅', label: 'Preview', desc: 'PR created, preview deploys' },
+  { icon: '🚀', label: 'Deployed', desc: 'You approve → it ships' },
+]
+
+const CYCLE_DURATION = 4 // seconds
+const STAGE_DELAY = CYCLE_DURATION / STAGES.length // 0.8s per stage
+
+export function PipelineExplainer() {
+  return (
+    <div>
+      <h2 className="mb-3 text-sm font-medium text-fg">How the Pipeline Works</h2>
+      <div className="glass-card p-5 sm:p-6">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-stretch sm:gap-0">
+          {STAGES.flatMap((stage, i) => {
+            const card = (
+              <div
+                key={stage.label}
+                className="flex-1 rounded-xl border border-white/[0.07] p-3 sm:p-4"
+                style={{
+                  background: 'rgba(255,255,255,0.03)',
+                  animationName: 'pipeline-stage-pulse',
+                  animationDuration: `${CYCLE_DURATION}s`,
+                  animationTimingFunction: 'ease-in-out',
+                  animationIterationCount: 'infinite',
+                  animationFillMode: 'backwards',
+                  animationDelay: `${i * STAGE_DELAY}s`,
+                }}
+              >
+                <div className="flex items-center gap-3 sm:flex-col sm:items-center sm:gap-2 sm:text-center">
+                  <span className="text-2xl leading-none" role="img" aria-label={stage.label}>
+                    {stage.icon}
+                  </span>
+                  <div className="min-w-0">
+                    <p className="text-xs font-semibold text-fg">{stage.label}</p>
+                    <p className="mt-0.5 text-[10px] leading-snug text-muted">{stage.desc}</p>
+                  </div>
+                </div>
+              </div>
+            )
+
+            if (i === STAGES.length - 1) return [card]
+
+            const connector = (
+              <div
+                key={`conn-${i}`}
+                className="flex shrink-0 items-center justify-center sm:w-5"
+              >
+                {/* Desktop: horizontal flowing dots */}
+                <div className="relative hidden h-0.5 w-5 overflow-hidden rounded-full bg-white/[0.07] sm:block">
+                  <span className="flow-dot" />
+                  <span className="flow-dot" />
+                  <span className="flow-dot" />
+                </div>
+                {/* Mobile: vertical down arrow */}
+                <div className="flex h-5 w-5 items-center justify-center sm:hidden">
+                  <svg
+                    width="10"
+                    height="10"
+                    viewBox="0 0 10 10"
+                    fill="none"
+                    className="text-muted"
+                    aria-hidden="true"
+                  >
+                    <path
+                      d="M5 1v8M2.5 6L5 8.5 7.5 6"
+                      stroke="currentColor"
+                      strokeWidth="1.2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </div>
+              </div>
+            )
+
+            return [card, connector]
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Creates `packages/dashboard/src/components/pipeline-explainer.tsx` — a 5-stage pipeline diagram (Chat → Issue → Agent → Preview → Deployed) with a CSS-only sequential pulse animation cycling every 4 seconds
- Adds `@keyframes pipeline-stage-pulse` to `globals.css` that highlights each stage card with an accent glow/border using `animation-delay` offsets (no JS required)
- Integrates the component into `packages/dashboard/src/app/projects/[id]/page.tsx` — renders above the runs table only when `runs.length === 0`
- Responsive: horizontal row with animated flow-dot connectors on desktop; vertical stack with down-arrow connectors on mobile
- Reuses existing design tokens (`glass-card`, `flow-dot`, `--color-accent`, `--color-muted`)

## Test plan

- [ ] Create a project with no pipeline runs — explainer should appear above the empty "Pipeline Runs" table
- [ ] Verify the 5 stage cards pulse left-to-right in sequence (Chat → Issue → Agent → Preview → Deployed), cycling every ~4 seconds
- [ ] Verify the active stage shows an accent-coloured glow/border highlight
- [ ] Add a pipeline run — explainer should disappear
- [ ] Check mobile (< 640px): stages stack vertically with down-arrow connectors
- [ ] Check desktop (≥ 640px): stages are in a horizontal row with animated dots between them

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)