### PR TITLE
feat: polish submit-request tool UI with glassmorphism success card

### DIFF
--- a/packages/widget/src/client/submit-request-tool-ui.tsx
+++ b/packages/widget/src/client/submit-request-tool-ui.tsx
@@ -60,9 +60,21 @@ function SubmissionResult({ args, result }: SubmissionResultProps) {
 
   return (
     <div className="space-y-3">
-      <div className="rounded-xl bg-muted/50 px-3 py-2.5">
-        <p className="text-[13px] leading-relaxed">{args.summary}</p>
+      <div className="rounded-xl border border-border bg-muted/30 px-3 py-3 flex items-start gap-2.5">
+        <div className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-emerald-500/15">
+          <Check className="h-3 w-3 text-emerald-400" />
+        </div>
+        <div>
+          <p className="text-[11px] font-medium uppercase tracking-wider text-emerald-400/80 mb-1">Feature request captured</p>
+          <p className="text-[13px] leading-relaxed text-foreground">{args.summary}</p>
+        </div>
       </div>
+
+      {!result?.github_issue_url && result?.success && (
+        <p className="text-[11px] text-muted-foreground">
+          Feedback recorded. Connect GitHub to track implementation.
+        </p>
+      )}
 
       {result?.github_issue_url && (
         <PipelineTracker issueUrl={result.github_issue_url} />
@@ -91,7 +103,7 @@ function SubmissionResult({ args, result }: SubmissionResultProps) {
         </button>
         {promptExpanded && (
           <pre
-            className="max-h-40 overflow-auto border-t border-border bg-[#0a0a0a] px-3 py-2.5 text-[11px] leading-relaxed text-zinc-400"
+            className="max-h-40 overflow-auto border-t border-border bg-black/40 px-3 py-2.5 text-[11px] leading-relaxed text-zinc-400"
             style={{ fontFamily: "'JetBrains Mono', monospace" }}
           >
             {args.generated_prompt}


### PR DESCRIPTION
## Summary

- Replaces the plain `bg-muted/50` summary box with a glassmorphism card featuring a green `Check` icon and an uppercase "Feature request captured" label, giving users clear visual confirmation their feedback was captured
- Adds a chat-only tier hint (`Feedback recorded. Connect GitHub to track implementation.`) shown when there is no GitHub issue URL but the submission succeeded
- Replaces the hardcoded `bg-[#0a0a0a]` in the generated-prompt `<pre>` with `bg-black/40` so it integrates with the glass theme

## Test plan
- [ ] Submit feedback in chat-only mode — summary card shows green checkmark + label, hint message appears below
- [ ] Submit feedback with GitHub configured — summary card shows green checkmark + label, PipelineTracker appears below (no hint)
- [ ] Expand the "Generated prompt" section — background matches glass theme

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Display feedback message when feature requests are successfully recorded without GitHub integration.

* **Style**
  * Redesigned feature request summary display with status indicator and styled bordered panel.
  * Updated generated prompt section background styling for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->