### PR TITLE
feat: add project health status indicators to projects list

### DIFF
--- a/packages/dashboard/src/app/projects/page.tsx
+++ b/packages/dashboard/src/app/projects/page.tsx
@@ -2,12 +2,35 @@ import Link from 'next/link'
 import { createClient } from '@/lib/supabase/server'
 import { Plus, Github, ChevronRight, Folder } from 'lucide-react'
 
+const ACTIVE_STAGES = ['created', 'queued', 'running', 'validating']
+
 export default async function ProjectsPage() {
   const supabase = await createClient()
   const { data: projects } = await supabase
     .from('projects')
     .select('id, name, github_repo, created_at')
     .order('created_at', { ascending: false })
+
+  // Fetch health stats for all projects in parallel bulk queries
+  let statsByProject = new Map<string, { totalRuns: number; activeRuns: number }>()
+
+  if (projects && projects.length > 0) {
+    const projectIds = projects.map((p) => p.id)
+    const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()
+
+    const { data: recentRuns } = await supabase
+      .from('pipeline_runs')
+      .select('project_id, stage')
+      .in('project_id', projectIds)
+      .gte('started_at', sevenDaysAgo)
+
+    for (const run of recentRuns ?? []) {
+      const current = statsByProject.get(run.project_id) ?? { totalRuns: 0, activeRuns: 0 }
+      current.totalRuns++
+      if (ACTIVE_STAGES.includes(run.stage)) current.activeRuns++
+      statsByProject.set(run.project_id, current)
+    }
+  }
 
   return (
     <div className="mx-auto max-w-5xl px-6 pt-10 pb-16">
@@ -40,24 +63,40 @@ export default async function ProjectsPage() {
         </div>
       ) : (
         <div className="grid gap-3">
-          {projects.map((p) => (
-            <Link
-              key={p.id}
-              href={`/projects/${p.id}`}
-              className="glass-card group flex items-center gap-4 px-5 py-4"
-            >
-              <div className="min-w-0 flex-1">
-                <h3 className="truncate text-sm font-medium text-fg group-hover:text-white">
-                  {p.name}
-                </h3>
-                <div className="mt-1 flex items-center gap-2 text-xs text-muted">
-                  <Github className="h-3 w-3 shrink-0" />
-                  <span className="truncate">{p.github_repo}</span>
+          {projects.map((p) => {
+            const stats = statsByProject.get(p.id) ?? { totalRuns: 0, activeRuns: 0 }
+            return (
+              <Link
+                key={p.id}
+                href={`/projects/${p.id}`}
+                className="glass-card group flex items-center gap-4 px-5 py-4"
+              >
+                <div className="min-w-0 flex-1">
+                  <h3 className="truncate text-sm font-medium text-fg group-hover:text-white">
+                    {p.name}
+                  </h3>
+                  <div className="mt-1 flex items-center gap-2 text-xs text-muted">
+                    <Github className="h-3 w-3 shrink-0" />
+                    <span className="truncate">{p.github_repo}</span>
+                  </div>
                 </div>
-              </div>
-              <ChevronRight className="h-4 w-4 shrink-0 text-muted/50 transition-colors group-hover:text-muted" />
-            </Link>
-          ))}
+                <div className="flex items-center gap-1.5 mr-3">
+                  {stats.activeRuns > 0 && (
+                    <span className="flex items-center gap-1 rounded-full bg-amber-400/10 px-2 py-0.5 text-[10px] font-medium text-amber-400">
+                      <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-amber-400" />
+                      {stats.activeRuns} running
+                    </span>
+                  )}
+                  {stats.totalRuns > 0 && (
+                    <span className="rounded-full bg-surface px-2 py-0.5 text-[10px] text-muted tabular-nums">
+                      {stats.totalRuns} runs
+                    </span>
+                  )}
+                </div>
+                <ChevronRight className="h-4 w-4 shrink-0 text-muted/50 transition-colors group-hover:text-muted" />
+              </Link>
+            )
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

- Fetches `pipeline_runs` counts (last 7 days) for all projects in a single bulk query — no N+1 waterfalls
- Aggregates active vs total runs in-memory using a fast Map
- Each project card shows a pulsing amber pill (`N running`) when there are active runs, and a quiet grey pill (`N runs`) for total run count
- Projects with zero runs show nothing extra, keeping the card clean

Closes #15

## Test plan

- [ ] Projects with active runs show amber pulsing indicator
- [ ] Projects with completed-only runs show grey run count
- [ ] New/empty projects show no extra pills
- [ ] Build passes (`next build` — confirmed locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)