### PR TITLE
feat: add animated activity indicator to running pipeline runs

### DIFF
--- a/packages/dashboard/src/app/projects/[id]/page.tsx
+++ b/packages/dashboard/src/app/projects/[id]/page.tsx
@@ -145,7 +145,24 @@ export default async function ProjectPage({
 
       {/* Runs table */}
       <div className="mb-8">
-        <h2 className="mb-4 text-sm font-medium text-fg">Pipeline Runs</h2>
+        {(() => {
+          const ACTIVE_STAGES = new Set(['running', 'validating', 'queued'])
+          const hasActiveRuns = (runs ?? []).some(r => !r.result && ACTIVE_STAGES.has(r.stage))
+          return (
+            <div className="mb-4 flex items-center gap-2">
+              <h2 className="text-sm font-medium text-fg">Pipeline Runs</h2>
+              {hasActiveRuns && (
+                <span className="flex items-center gap-1.5 rounded-full bg-accent/10 px-2 py-0.5 text-[11px] font-medium text-accent">
+                  <span className="relative flex h-1.5 w-1.5">
+                    <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-accent opacity-60" />
+                    <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-accent" />
+                  </span>
+                  Live
+                </span>
+              )}
+            </div>
+          )
+        })()}
         <RunsTable runs={enrichedRuns} githubRepo={project.github_repo} projectId={project.id} />
       </div>
     </div>

--- a/packages/dashboard/src/components/runs-table.tsx
+++ b/packages/dashboard/src/components/runs-table.tsx
@@ -1,10 +1,30 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { ExternalLink, MessageCircle } from 'lucide-react'
 import { StageBadge } from './stage-badge'
 import { RunSlideOver } from './run-slide-over'
 import type { EnrichedPipelineRun } from '@/lib/types'
+
+const ACTIVE_STAGES = new Set(['running', 'validating', 'queued'])
+
+function elapsed(startedAt: string): string {
+  const ms = Date.now() - new Date(startedAt).getTime()
+  const s = Math.floor(ms / 1000)
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m}m ${s % 60}s`
+  return `${Math.floor(m / 60)}h ${m % 60}m`
+}
+
+function ElapsedTimer({ startedAt }: { startedAt: string }) {
+  const [, tick] = useState(0)
+  useEffect(() => {
+    const id = setInterval(() => tick((n) => n + 1), 1000)
+    return () => clearInterval(id)
+  }, [])
+  return <>{elapsed(startedAt)}</>
+}
 
 type Props = {
   runs: EnrichedPipelineRun[]
@@ -40,59 +60,74 @@ export function RunsTable({ runs, githubRepo, projectId }: Props) {
             </tr>
           </thead>
           <tbody>
-            {runs.map((run) => (
-              <tr
-                key={run.id}
-                onClick={() => setSelectedRun(run)}
-                className="cursor-pointer border-b border-edge/50 transition-colors last:border-0 hover:bg-surface-hover"
-              >
-                <td className="px-5 py-3 font-[family-name:var(--font-mono)] text-xs text-fg">
-                  #{run.github_issue_number}
-                </td>
-                <td className="max-w-[200px] px-5 py-3">
-                  {run.feedback_source ? (
+            {runs.map((run) => {
+              const isActive = !run.result && ACTIVE_STAGES.has(run.stage)
+              return (
+                <tr
+                  key={run.id}
+                  onClick={() => setSelectedRun(run)}
+                  className="cursor-pointer border-b border-edge/50 transition-colors last:border-0 hover:bg-surface-hover"
+                >
+                  <td className="px-5 py-3 font-[family-name:var(--font-mono)] text-xs text-fg">
+                    #{run.github_issue_number}
+                  </td>
+                  <td className="max-w-[200px] px-5 py-3">
+                    {run.feedback_source ? (
+                      <div className="flex items-center gap-1.5">
+                        <MessageCircle className="h-3 w-3 shrink-0 text-accent" />
+                        <span className="truncate text-xs text-fg">
+                          {run.feedback_source.tester_name || 'Anonymous'}
+                        </span>
+                      </div>
+                    ) : (
+                      <span className="text-xs text-dim">Manual</span>
+                    )}
+                  </td>
+                  <td className="px-5 py-3">
                     <div className="flex items-center gap-1.5">
-                      <MessageCircle className="h-3 w-3 shrink-0 text-accent" />
-                      <span className="truncate text-xs text-fg">
-                        {run.feedback_source.tester_name || 'Anonymous'}
-                      </span>
+                      {isActive && run.stage !== 'running' && (
+                        <span className="relative flex h-1.5 w-1.5 shrink-0">
+                          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-accent opacity-60" />
+                          <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-accent" />
+                        </span>
+                      )}
+                      <StageBadge stage={run.stage} />
                     </div>
-                  ) : (
-                    <span className="text-xs text-dim">Manual</span>
-                  )}
-                </td>
-                <td className="px-5 py-3">
-                  <StageBadge stage={run.stage} />
-                </td>
-                <td className="px-5 py-3 text-xs text-muted">
-                  {run.result ?? <span className="text-dim">&mdash;</span>}
-                </td>
-                <td className="px-5 py-3">
-                  {run.github_pr_number ? (
-                    <a
-                      href={`https://github.com/${githubRepo}/pull/${run.github_pr_number}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      onClick={(e) => e.stopPropagation()}
-                      className="inline-flex items-center gap-1 text-xs text-accent transition-colors hover:text-accent/80"
-                    >
-                      #{run.github_pr_number}
-                      <ExternalLink className="h-2.5 w-2.5" />
-                    </a>
-                  ) : (
-                    <span className="text-xs text-dim">&mdash;</span>
-                  )}
-                </td>
-                <td className="px-5 py-3 text-xs text-muted tabular-nums">
-                  {new Date(run.started_at).toLocaleDateString(undefined, {
-                    month: 'short',
-                    day: 'numeric',
-                    hour: '2-digit',
-                    minute: '2-digit',
-                  })}
-                </td>
-              </tr>
-            ))}
+                  </td>
+                  <td className="px-5 py-3 text-xs text-muted">
+                    {run.result ?? <span className="text-dim">&mdash;</span>}
+                  </td>
+                  <td className="px-5 py-3">
+                    {run.github_pr_number ? (
+                      <a
+                        href={`https://github.com/${githubRepo}/pull/${run.github_pr_number}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={(e) => e.stopPropagation()}
+                        className="inline-flex items-center gap-1 text-xs text-accent transition-colors hover:text-accent/80"
+                      >
+                        #{run.github_pr_number}
+                        <ExternalLink className="h-2.5 w-2.5" />
+                      </a>
+                    ) : (
+                      <span className="text-xs text-dim">&mdash;</span>
+                    )}
+                  </td>
+                  <td className="px-5 py-3 text-xs text-muted tabular-nums">
+                    {isActive ? (
+                      <ElapsedTimer startedAt={run.started_at} />
+                    ) : (
+                      new Date(run.started_at).toLocaleDateString(undefined, {
+                        month: 'short',
+                        day: 'numeric',
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      })
+                    )}
+                  </td>
+                </tr>
+              )
+            })}
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
## Summary

- **`runs-table.tsx`**: Active runs (`running`, `validating`, `queued` with no result) now show a pulsing dot alongside the stage badge (skipping `running` since `StageBadge` already has an internal ping). The "Started" column switches to a live elapsed timer that ticks every second via `useEffect`, with cleanup on unmount to prevent memory leaks.
- **`pipeline-tab.tsx`**: Added an `ElapsedTimer` component so In Progress lane cards show real-time elapsed time instead of a static snapshot. Active run cards get a subtle blue glow (`shadow-[0_0_20px_rgba(94,158,255,0.08)]`) to visually distinguish them from completed items.
- **`page.tsx` (project overview)**: A "Live" pill with a pulsing dot appears next to the Pipeline Runs section heading whenever any run is in a non-terminal stage (`running`, `validating`, or `queued`). Computed server-side from fetched run data — no extra client JS needed.

## Test plan
- [ ] Start a pipeline run and verify the runs table shows a live counter and pulsing dot
- [ ] Verify the Pipeline Runs heading shows the "Live" badge while a run is active and disappears once all runs complete
- [ ] Confirm In Progress cards on the Minions page show real-time elapsed time and the blue glow
- [ ] Navigate away and back — confirm timers restart without memory leaks

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)