### PR TITLE
feat: improve run detail page layout and visual clarity

### DIFF
--- a/packages/dashboard/src/app/projects/[id]/runs/[runId]/page.tsx
+++ b/packages/dashboard/src/app/projects/[id]/runs/[runId]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import Link from 'next/link'
-import { ArrowLeft, ExternalLink, GitPullRequest, AlertCircle, Globe } from 'lucide-react'
+import { ArrowLeft, ExternalLink, GitPullRequest, AlertCircle, Clock } from 'lucide-react'
 import { StageBadge } from '@/components/stage-badge'
 import { LogViewer } from '@/components/log-viewer'
 import { DeploymentPreview } from '@/components/deployment-preview'
@@ -70,14 +70,31 @@ export default async function RunDetailPage({
       </Link>
 
       {/* Header */}
-      <div className="mb-8 flex items-center gap-4">
-        <h1 className="text-lg font-medium text-fg">
-          Run <span className="font-[family-name:var(--font-mono)]">#{run.github_issue_number}</span>
-        </h1>
-        <StageBadge stage={run.stage} />
-        {duration && (
-          <span className="text-xs text-muted tabular-nums">{duration}</span>
-        )}
+      <div className="mb-8">
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="text-lg font-medium text-fg">
+            Run <span className="font-[family-name:var(--font-mono)]">#{run.github_issue_number}</span>
+          </h1>
+          <StageBadge stage={run.stage} />
+          {run.github_pr_number && (
+            <a
+              href={`https://github.com/${project.github_repo}/pull/${run.github_pr_number}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 rounded-full bg-accent/10 px-2.5 py-0.5 text-xs font-medium text-accent transition-colors hover:bg-accent/15"
+            >
+              <GitPullRequest className="h-3 w-3" />
+              PR #{run.github_pr_number}
+              <ExternalLink className="h-2.5 w-2.5 opacity-60" />
+            </a>
+          )}
+          {duration && (
+            <span className="inline-flex items-center gap-1 text-xs text-muted tabular-nums">
+              <Clock className="h-3 w-3" />
+              {duration}
+            </span>
+          )}
+        </div>
       </div>
 
       <div className="grid gap-6 lg:grid-cols-3">
@@ -92,7 +109,7 @@ export default async function RunDetailPage({
           {/* Deployment preview */}
           <div>
             <h2 className="mb-3 text-sm font-medium text-fg">Deployment Preview</h2>
-            <DeploymentPreview projectId={projectId} runId={runId} />
+            <DeploymentPreview projectId={projectId} runId={runId} stage={run.stage} />
           </div>
         </div>
 

--- a/packages/dashboard/src/components/deployment-preview.tsx
+++ b/packages/dashboard/src/components/deployment-preview.tsx
@@ -1,12 +1,23 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { Globe, ExternalLink } from 'lucide-react'
+import { Globe, ExternalLink, Sparkles } from 'lucide-react'
 import type { DeploymentInfo } from '@/lib/types'
 
-export function DeploymentPreview({ projectId, runId }: { projectId: string; runId: string }) {
+const PREVIEW_STAGES = ['preview_ready', 'deployed']
+
+export function DeploymentPreview({
+  projectId,
+  runId,
+  stage,
+}: {
+  projectId: string
+  runId: string
+  stage?: string
+}) {
   const [deployment, setDeployment] = useState<DeploymentInfo | null>(null)
   const [loading, setLoading] = useState(true)
+  const isPreviewActive = stage ? PREVIEW_STAGES.includes(stage) : false
 
   useEffect(() => {
     fetch(`/api/runs/${projectId}/${runId}/deployment`)
@@ -18,9 +29,9 @@ export function DeploymentPreview({ projectId, runId }: { projectId: string; run
 
   if (loading) {
     return (
-      <div className="glass-card p-5">
-        <div className="skeleton h-4 w-48 mb-2" />
-        <div className="skeleton h-32 w-full" />
+      <div className={`glass-card overflow-hidden ${isPreviewActive ? 'ring-1 ring-success/20' : ''}`}>
+        <div className="skeleton h-4 w-48 m-5 mb-3" />
+        <div className="skeleton h-32 w-full rounded-none" />
       </div>
     )
   }
@@ -37,21 +48,33 @@ export function DeploymentPreview({ projectId, runId }: { projectId: string; run
   }
 
   return (
-    <div className="glass-card overflow-hidden">
-      <div className="flex items-center justify-between border-b border-edge px-4 py-2.5">
-        <div className="flex items-center gap-2 text-xs text-muted">
-          <Globe className="h-3.5 w-3.5" />
+    <div className={`glass-card overflow-hidden transition-all ${isPreviewActive ? 'ring-1 ring-success/30 shadow-[0_0_24px_rgba(34,197,94,0.06)]' : ''}`}>
+      {/* Preview-ready banner */}
+      {isPreviewActive && (
+        <div className="flex items-center gap-2 bg-success/10 border-b border-success/20 px-4 py-2.5">
+          <Sparkles className="h-3.5 w-3.5 text-success shrink-0" />
+          <span className="text-xs font-medium text-success">
+            {stage === 'deployed' ? 'Deployed to production' : 'Preview ready — review the changes below'}
+          </span>
+        </div>
+      )}
+
+      {/* URL bar */}
+      <div className="flex items-center justify-between border-b border-edge px-4 py-2.5 bg-surface">
+        <div className="flex items-center gap-2 text-xs text-muted min-w-0">
+          <Globe className="h-3.5 w-3.5 shrink-0" />
           <span className="truncate">{deployment.previewUrl.replace('https://', '')}</span>
         </div>
         <a
           href={deployment.previewUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-xs text-accent transition-colors hover:text-accent/80"
+          className="ml-3 shrink-0 text-xs text-accent transition-colors hover:text-accent/80"
         >
           <ExternalLink className="h-3.5 w-3.5" />
         </a>
       </div>
+
       <iframe
         src={deployment.previewUrl}
         className="h-[400px] w-full border-0 bg-white"

--- a/packages/dashboard/src/components/log-viewer.tsx
+++ b/packages/dashboard/src/components/log-viewer.tsx
@@ -1,11 +1,22 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { Copy, Check } from 'lucide-react'
 import type { RunLog } from '@/lib/types'
+
+function logLevelClass(level: string): string {
+  switch (level) {
+    case 'error': return 'text-danger'
+    case 'warn': return 'text-[#fbbf24]'
+    case 'success': return 'text-success'
+    default: return 'text-dim'
+  }
+}
 
 export function LogViewer({ projectId, runId }: { projectId: string; runId: string }) {
   const [logs, setLogs] = useState<RunLog[]>([])
   const [loading, setLoading] = useState(true)
+  const [copied, setCopied] = useState(false)
 
   useEffect(() => {
     fetch(`/api/runs/${projectId}/${runId}/logs`)
@@ -15,44 +26,80 @@ export function LogViewer({ projectId, runId }: { projectId: string; runId: stri
       .finally(() => setLoading(false))
   }, [projectId, runId])
 
+  function copyLogs() {
+    const text = logs
+      .map((log) => `${new Date(log.timestamp).toLocaleTimeString()} [${log.level}] ${log.message}`)
+      .join('\n')
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    })
+  }
+
   if (loading) {
     return (
-      <div className="code-block">
-        <div className="skeleton h-4 w-64 mb-2" />
-        <div className="skeleton h-4 w-48 mb-2" />
-        <div className="skeleton h-4 w-56" />
+      <div className="rounded-xl overflow-hidden border border-white/[0.06] bg-[#0d0d0f]">
+        <div className="border-b border-white/[0.06] px-4 py-2.5">
+          <div className="skeleton h-3 w-24" />
+        </div>
+        <div className="px-4 py-4 space-y-2">
+          <div className="skeleton h-3.5 w-64" />
+          <div className="skeleton h-3.5 w-48" />
+          <div className="skeleton h-3.5 w-56" />
+        </div>
       </div>
     )
   }
 
   if (logs.length === 0) {
     return (
-      <div className="code-block text-center text-muted">
-        No logs available for this run.
+      <div className="rounded-xl border border-white/[0.06] bg-[#0d0d0f] px-4 py-8 text-center">
+        <p className="font-mono text-xs text-muted">No logs available for this run.</p>
       </div>
     )
   }
 
   return (
-    <div className="code-block max-h-[500px] overflow-y-auto whitespace-pre-wrap">
-      {logs.map((log) => (
-        <div key={log.id} className="flex gap-3">
-          <span className="shrink-0 text-dim tabular-nums">
-            {new Date(log.timestamp).toLocaleTimeString()}
-          </span>
-          <span
-            className={
-              log.level === 'error'
-                ? 'text-danger'
-                : log.level === 'warn'
-                  ? 'text-[#fbbf24]'
-                  : ''
-            }
+    <div className="rounded-xl overflow-hidden border border-white/[0.06]">
+      {/* Toolbar */}
+      <div className="flex items-center justify-between bg-[#0d0d0f] border-b border-white/[0.06] px-4 py-2.5">
+        <span className="font-mono text-xs text-dim">{logs.length} lines</span>
+        <button
+          onClick={copyLogs}
+          className="flex items-center gap-1.5 text-xs text-muted hover:text-fg transition-colors"
+        >
+          {copied
+            ? <><Check className="h-3.5 w-3.5 text-success" />Copied!</>
+            : <><Copy className="h-3.5 w-3.5" />Copy logs</>
+          }
+        </button>
+      </div>
+
+      {/* Log lines */}
+      <div
+        className="bg-[#0d0d0f] max-h-[480px] overflow-y-auto font-mono text-xs leading-relaxed"
+        style={{ scrollbarWidth: 'none' }}
+      >
+        {logs.map((log, i) => (
+          <div
+            key={log.id}
+            className="group flex gap-0 hover:bg-white/[0.02] px-4 py-[1px]"
           >
-            {log.message}
-          </span>
-        </div>
-      ))}
+            {/* Line number */}
+            <span className="shrink-0 w-9 text-right text-white/20 select-none mr-4 tabular-nums">
+              {i + 1}
+            </span>
+            {/* Timestamp */}
+            <span className="shrink-0 text-white/30 tabular-nums mr-4">
+              {new Date(log.timestamp).toLocaleTimeString()}
+            </span>
+            {/* Message */}
+            <span className={logLevelClass(log.level)}>
+              {log.message}
+            </span>
+          </div>
+        ))}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- **LogViewer**: Line numbers on every log line, a "Copy logs" button in a toolbar header, and proper `success` log-level coloring (green) alongside existing `error`/`warn`
- **DeploymentPreview**: Accepts a `stage` prop; shows a green banner ("Preview ready" / "Deployed to production") with a ring highlight when stage is `preview_ready` or `deployed`
- **Page header**: PR number now appears inline as a badge/link next to the stage badge; duration gets a Clock icon for quick scannability

## Test plan

- [ ] Open a run detail page and verify logs show line numbers and timestamps
- [ ] Click "Copy logs" — confirm clipboard receives formatted log text
- [ ] Verify error logs are red, warn is yellow, success is green, info/default is dim
- [ ] Open a run in `preview_ready` or `deployed` stage — confirm green banner appears above the iframe
- [ ] On a run with a PR, confirm the PR badge appears in the header and links correctly
- [ ] Build passes: `cd packages/dashboard && npx next build` ✅

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)