### PR TITLE
feat: add live demo widget to landing page

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -10,6 +10,10 @@
     "test:e2e:headed": "playwright test --headed"
   },
   "dependencies": {
+    "@nikitadmitrieff/feedback-chat": "*",
+    "@assistant-ui/react": "*",
+    "@assistant-ui/react-ai-sdk": "*",
+    "@assistant-ui/react-markdown": "*",
     "@ai-sdk/anthropic": "^3.0.44",
     "@anthropic-ai/sdk": "^0.78.0",
     "@octokit/app": "^16.1.2",

--- a/packages/dashboard/src/app/api/demo/chat/route.ts
+++ b/packages/dashboard/src/app/api/demo/chat/route.ts
@@ -1,0 +1,9 @@
+import { createFeedbackHandler } from '@nikitadmitrieff/feedback-chat/server'
+
+const handler = createFeedbackHandler({
+  password: process.env.DEMO_FEEDBACK_PASSWORD ?? 'demo',
+  projectContext:
+    'This is a demo of feedback-chat, an AI-powered feedback widget for Next.js apps. The widget lets users submit feedback, which gets turned into GitHub issues and optionally implemented automatically by an AI agent. Help visitors understand what feedback-chat does, how to install it, and what problems it solves.',
+})
+
+export const POST = handler.POST

--- a/packages/dashboard/src/app/api/demo/status/route.ts
+++ b/packages/dashboard/src/app/api/demo/status/route.ts
@@ -1,0 +1,7 @@
+import { createStatusHandler } from '@nikitadmitrieff/feedback-chat/server'
+
+const handler = createStatusHandler({
+  password: process.env.DEMO_FEEDBACK_PASSWORD ?? 'demo',
+})
+
+export const { GET, POST } = handler

--- a/packages/dashboard/src/app/page.tsx
+++ b/packages/dashboard/src/app/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { MessageSquare, Github, Zap, Terminal, ArrowRight, Check } from 'lucide-react'
+import { DemoWidget } from '@/components/demo-widget'
 
 export default function Home() {
   return (
@@ -60,6 +61,54 @@ export default function Home() {
             <Github className="h-4 w-4" />
             View on GitHub
           </a>
+        </div>
+      </section>
+
+      {/* Live demo */}
+      <section className="px-6 pb-20 max-w-4xl mx-auto w-full">
+        <p className="text-center text-xs font-medium text-[var(--color-muted)] uppercase tracking-wider mb-4">
+          Try it now
+        </p>
+        <h2 className="text-center text-xl font-semibold text-[var(--color-fg)] mb-2">
+          Chat with the AI advisor
+        </h2>
+        <p className="text-center text-sm text-[var(--color-muted)] mb-10 max-w-lg mx-auto">
+          This is exactly what your users will see. Ask anything about feedback-chat or submit a feature idea.
+        </p>
+        <div className="flex flex-col md:flex-row items-start gap-10">
+          <div className="flex-1 space-y-6">
+            <div className="glass-card p-5">
+              <div className="flex items-center gap-3 mb-3">
+                <div className="h-8 w-8 rounded-lg bg-[rgba(94,158,255,0.10)] flex items-center justify-center shrink-0">
+                  <MessageSquare className="h-4 w-4 text-[#5e9eff]" />
+                </div>
+                <div>
+                  <div className="text-sm font-medium text-[var(--color-fg)]">Embedded widget</div>
+                  <div className="text-xs text-[var(--color-muted)]">Floats in your app, no page navigation</div>
+                </div>
+              </div>
+              <p className="text-xs text-[var(--color-muted)] leading-relaxed">
+                Drop it into any Next.js app in minutes. Your users can share ideas without leaving the page.
+              </p>
+            </div>
+            <div className="glass-card p-5">
+              <div className="flex items-center gap-3 mb-3">
+                <div className="h-8 w-8 rounded-lg bg-[rgba(34,197,94,0.10)] flex items-center justify-center shrink-0">
+                  <Zap className="h-4 w-4 text-[#22c55e]" />
+                </div>
+                <div>
+                  <div className="text-sm font-medium text-[var(--color-fg)]">AI-guided conversations</div>
+                  <div className="text-xs text-[var(--color-muted)]">Turns vague ideas into actionable specs</div>
+                </div>
+              </div>
+              <p className="text-xs text-[var(--color-muted)] leading-relaxed">
+                The advisor asks the right questions, then generates a precise prompt for your AI agent.
+              </p>
+            </div>
+          </div>
+          <div className="w-full md:w-[400px] shrink-0">
+            <DemoWidget />
+          </div>
         </div>
       </section>
 

--- a/packages/dashboard/src/components/demo-widget.tsx
+++ b/packages/dashboard/src/components/demo-widget.tsx
@@ -1,0 +1,152 @@
+'use client'
+
+import { type FC } from 'react'
+import {
+  AssistantRuntimeProvider,
+  useAui,
+  Suggestions,
+  AuiIf,
+  ThreadPrimitive,
+  ComposerPrimitive,
+  MessagePrimitive,
+  SuggestionPrimitive,
+} from '@assistant-ui/react'
+import { useChatRuntime } from '@assistant-ui/react-ai-sdk'
+import { DefaultChatTransport } from 'ai'
+import { ArrowUp, Square } from 'lucide-react'
+import '@nikitadmitrieff/feedback-chat/styles.css'
+
+function DemoThread() {
+  return (
+    <ThreadPrimitive.Root className="aui-root aui-thread-root flex h-full flex-col bg-transparent">
+      <ThreadPrimitive.Viewport className="relative flex flex-1 flex-col overflow-y-auto scroll-smooth px-4 pt-4">
+        <AuiIf condition={(s) => s.thread.isEmpty}>
+          <div className="flex w-full grow flex-col items-center justify-center gap-2 px-4 text-center py-8">
+            <p className="text-sm font-medium text-foreground">What can we improve?</p>
+            <p className="text-xs text-muted-foreground">Ask about feedback-chat or submit an idea.</p>
+            <div className="grid w-full gap-2 mt-3 max-w-xs">
+              <ThreadPrimitive.Suggestions components={{ Suggestion: DemoSuggestion }} />
+            </div>
+          </div>
+        </AuiIf>
+
+        <ThreadPrimitive.Messages
+          components={{ UserMessage: DemoUserMessage, AssistantMessage: DemoAssistantMessage }}
+        />
+
+        <ThreadPrimitive.ViewportFooter className="sticky bottom-0 mt-auto flex w-full flex-col gap-3 overflow-visible pb-3">
+          <DemoComposer />
+        </ThreadPrimitive.ViewportFooter>
+      </ThreadPrimitive.Viewport>
+    </ThreadPrimitive.Root>
+  )
+}
+
+const DemoSuggestion: FC = () => (
+  <div className="animate-in fade-in slide-in-from-bottom-2 duration-200">
+    <SuggestionPrimitive.Trigger send asChild>
+      <button className="w-full text-left text-xs px-3 py-2 rounded-xl border border-white/[0.08] text-muted-foreground hover:text-foreground hover:border-white/[0.14] transition-colors">
+        <span className="font-medium">
+          <SuggestionPrimitive.Title />
+        </span>
+      </button>
+    </SuggestionPrimitive.Trigger>
+  </div>
+)
+
+const DemoUserMessage: FC = () => (
+  <MessagePrimitive.Root
+    className="animate-in fade-in slide-in-from-bottom-1 mx-auto flex w-full justify-end py-1 duration-150"
+    data-role="user"
+  >
+    <div className="max-w-[85%] rounded-2xl bg-white/[0.10] px-3 py-2 text-xs text-foreground leading-relaxed">
+      <MessagePrimitive.Parts />
+    </div>
+  </MessagePrimitive.Root>
+)
+
+const DemoAssistantMessage: FC = () => (
+  <MessagePrimitive.Root
+    className="animate-in fade-in slide-in-from-bottom-1 mx-auto w-full py-1 duration-150"
+    data-role="assistant"
+  >
+    <div className="text-xs text-foreground leading-relaxed px-1">
+      <MessagePrimitive.Parts />
+    </div>
+  </MessagePrimitive.Root>
+)
+
+const DemoComposer: FC = () => (
+  <ComposerPrimitive.Root className="relative flex w-full flex-col">
+    <div className="flex items-center gap-2 rounded-2xl border border-white/[0.08] bg-white/[0.04] px-3 py-1">
+      <ComposerPrimitive.Input
+        placeholder="Describe your idea..."
+        className="flex-1 bg-transparent py-2 text-xs text-foreground outline-none placeholder:text-muted-foreground focus-visible:ring-0 resize-none max-h-24"
+        rows={1}
+        autoFocus
+        aria-label="Message input"
+      />
+      <AuiIf condition={(s) => !s.thread.isRunning}>
+        <ComposerPrimitive.Send asChild>
+          <button
+            type="submit"
+            className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-white/10 transition-colors hover:bg-white/15 disabled:opacity-30"
+            aria-label="Send message"
+          >
+            <ArrowUp className="h-3 w-3 text-muted-foreground" />
+          </button>
+        </ComposerPrimitive.Send>
+      </AuiIf>
+      <AuiIf condition={(s) => s.thread.isRunning}>
+        <ComposerPrimitive.Cancel asChild>
+          <button
+            type="button"
+            className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-white/10 transition-colors hover:bg-white/15"
+            aria-label="Stop generating"
+          >
+            <Square className="h-2.5 w-2.5 fill-current text-muted-foreground" />
+          </button>
+        </ComposerPrimitive.Cancel>
+      </AuiIf>
+    </div>
+  </ComposerPrimitive.Root>
+)
+
+function DemoChatProvider() {
+  const runtime = useChatRuntime({
+    transport: new DefaultChatTransport({
+      api: '/api/demo/chat',
+      body: () => ({
+        password: 'demo',
+        testerName: 'Demo visitor',
+      }),
+    }),
+  })
+
+  const aui = useAui({
+    suggestions: Suggestions([
+      'How does the feedback widget work?',
+      'What is the pipeline feature?',
+      'How do I install feedback-chat?',
+      'What makes this different from other tools?',
+    ]),
+  })
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime} aui={aui}>
+      <div className="feedback-panel" style={{ position: 'relative', height: '100%' }}>
+        <div className="feedback-panel-glass flex flex-col h-full overflow-hidden">
+          <DemoThread />
+        </div>
+      </div>
+    </AssistantRuntimeProvider>
+  )
+}
+
+export function DemoWidget() {
+  return (
+    <div className="w-full" style={{ height: '520px' }}>
+      <DemoChatProvider />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Embeds an interactive AI feedback advisor directly on the landing page so visitors can try it without installing anything
- Auto-authenticates with demo password — no PasswordGate or NameGate shown
- Uses `@assistant-ui/react` primitives to build a clean Thread UI matching the dashboard glassmorphism theme
- Creates `/api/demo/chat` and `/api/demo/status` routes using the widget's `createFeedbackHandler` / `createStatusHandler`

## Changes

- **`packages/dashboard/src/app/api/demo/chat/route.ts`** — Chat handler using `createFeedbackHandler` with demo project context and `DEMO_FEEDBACK_PASSWORD` env var (defaults to `'demo'`)
- **`packages/dashboard/src/app/api/demo/status/route.ts`** — Status handler for demo (no GitHub pipeline)
- **`packages/dashboard/src/components/demo-widget.tsx`** — Client component using `AssistantRuntimeProvider` + @assistant-ui primitives; hardcodes the demo password, skips auth gates, shows the chat immediately
- **`packages/dashboard/src/app/page.tsx`** — New "Try it now" section between hero and "How it works", with the DemoWidget on the right and feature highlights on the left
- **`packages/dashboard/package.json`** — Adds `@nikitadmitrieff/feedback-chat`, `@assistant-ui/react`, `@assistant-ui/react-ai-sdk`, `@assistant-ui/react-markdown` as dependencies

## Test plan

- [ ] Landing page renders without errors
- [ ] "Try it now" section is visible below the hero
- [ ] Suggestion chips are clickable and populate the input
- [ ] Typing and sending a message works without entering a password
- [ ] AI responds with information about feedback-chat
- [ ] Build passes (`npm run build` in `packages/dashboard`)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)