### PR TITLE
feat: polish new project page with onboarding UX (#30)

### DIFF
--- a/packages/dashboard/src/app/projects/new/page.tsx
+++ b/packages/dashboard/src/app/projects/new/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import { generateApiKey } from '@/lib/api-keys'
 import crypto from 'node:crypto'
+import { MessageSquare, GitBranch, Zap, CheckCircle2 } from 'lucide-react'
 import { SubmitButton } from './submit-button'
 
 export default function NewProjectPage() {
@@ -12,11 +13,12 @@ export default function NewProjectPage() {
     if (!user) redirect('/login')
 
     const name = formData.get('name') as string
+    const githubRepo = formData.get('github_repo') as string | null
     const webhookSecret = crypto.randomBytes(32).toString('hex')
 
     const { data: project, error } = await supabase
       .from('projects')
-      .insert({ name, webhook_secret: webhookSecret, user_id: user.id })
+      .insert({ name, github_repo: githubRepo || null, webhook_secret: webhookSecret, user_id: user.id })
       .select('id')
       .single()
 
@@ -34,9 +36,18 @@ export default function NewProjectPage() {
 
   return (
     <div className="mx-auto max-w-lg px-6 pt-10 pb-16">
-      <div className="glass-card p-6">
-        <h1 className="mb-6 text-base font-medium text-fg">New Project</h1>
+      {/* Header */}
+      <div className="mb-8 text-center">
+        <div className="mb-4 inline-flex items-center justify-center rounded-2xl bg-accent/10 p-3 ring-1 ring-accent/20 shadow-[0_0_24px_rgba(94,158,255,0.15)]">
+          <MessageSquare className="h-6 w-6 text-accent" />
+        </div>
+        <h1 className="text-xl font-semibold text-fg">Set up a new project</h1>
+        <p className="mt-2 text-sm text-muted">
+          Connect your app to start receiving and acting on user feedback
+        </p>
+      </div>
 
+      <div className="glass-card p-6">
         <form action={createProject} className="space-y-5">
           <div className="space-y-1.5">
             <label className="text-xs font-medium text-muted">Project name</label>
@@ -48,8 +59,47 @@ export default function NewProjectPage() {
             />
           </div>
 
+          <div className="space-y-1.5">
+            <label className="text-xs font-medium text-muted">
+              GitHub repository
+              <span className="ml-1.5 text-[10px] font-normal text-muted/60">(optional)</span>
+            </label>
+            <input
+              name="github_repo"
+              placeholder="owner/repo"
+              className="input-field"
+            />
+            <p className="text-[11px] text-muted/50">Required for the full pipeline</p>
+          </div>
+
           <SubmitButton />
         </form>
+
+        {/* 3-step flow */}
+        <div className="mt-6 pt-5 border-t border-white/[0.06]">
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex flex-1 flex-col items-center gap-1.5 text-center">
+              <div className="flex h-7 w-7 items-center justify-center rounded-full bg-accent/10 ring-1 ring-accent/20">
+                <MessageSquare className="h-3.5 w-3.5 text-accent" />
+              </div>
+              <span className="text-[11px] font-medium text-muted/70">Connect widget</span>
+            </div>
+            <div className="flex-shrink-0 text-muted/30 text-xs">→</div>
+            <div className="flex flex-1 flex-col items-center gap-1.5 text-center">
+              <div className="flex h-7 w-7 items-center justify-center rounded-full bg-accent/10 ring-1 ring-accent/20">
+                <GitBranch className="h-3.5 w-3.5 text-accent" />
+              </div>
+              <span className="text-[11px] font-medium text-muted/70">Collect feedback</span>
+            </div>
+            <div className="flex-shrink-0 text-muted/30 text-xs">→</div>
+            <div className="flex flex-1 flex-col items-center gap-1.5 text-center">
+              <div className="flex h-7 w-7 items-center justify-center rounded-full bg-accent/10 ring-1 ring-accent/20">
+                <Zap className="h-3.5 w-3.5 text-accent" />
+              </div>
+              <span className="text-[11px] font-medium text-muted/70">Ship features</span>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/packages/dashboard/src/app/projects/new/submit-button.tsx
+++ b/packages/dashboard/src/app/projects/new/submit-button.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useFormStatus } from 'react-dom'
-import { Loader2 } from 'lucide-react'
+import { Loader2, ArrowRight } from 'lucide-react'
 
 export function SubmitButton() {
   const { pending } = useFormStatus()
@@ -12,8 +12,17 @@ export function SubmitButton() {
       disabled={pending}
       className="btn-primary flex h-10 w-full items-center justify-center gap-2 rounded-xl text-sm font-medium"
     >
-      {pending && <Loader2 className="h-4 w-4 animate-spin" />}
-      {pending ? 'Creating...' : 'Create Project'}
+      {pending ? (
+        <>
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Creating...
+        </>
+      ) : (
+        <>
+          Create Project
+          <ArrowRight className="h-4 w-4" />
+        </>
+      )}
     </button>
   )
 }


### PR DESCRIPTION
## Summary

- Adds a welcoming header with MessageSquare icon (accent glow), title "Set up a new project", and subtitle
- Adds optional GitHub repository field (`owner/repo`) with a "Required for the full pipeline" hint; wired through the server action to `projects.github_repo`
- Adds a non-interactive 3-step visual below the form: Connect widget → Collect feedback → Ship features
- Updates the `SubmitButton` to show "Create Project →" with an `ArrowRight` icon (spinner on pending state unchanged)

## Test plan

- [ ] Navigate to `/projects/new` — header, subtitle, and icon should render above the glass card
- [ ] Both inputs (Project name required, GitHub repo optional) appear correctly
- [ ] Submit with only a project name → project created, redirects to project page
- [ ] Submit with both fields → `github_repo` saved to Supabase projects row
- [ ] Button shows "Create Project →" at rest and spinner + "Creating..." while submitting
- [ ] 3-step flow renders below the form inside the glass card

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)