### PR TITLE
feat: smooth panel open/close animation + backdrop overlay

### DIFF
--- a/packages/widget/src/client/feedback-panel.tsx
+++ b/packages/widget/src/client/feedback-panel.tsx
@@ -137,9 +137,18 @@ export function FeedbackPanel({ isOpen, onToggle, apiUrl = '/api/feedback/chat' 
         </div>
       </div>
 
+      {/* Backdrop */}
+      <div
+        className={`feedback-panel fixed inset-0 z-40 transition-opacity duration-300 ${
+          isOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
+        }`}
+        style={{ background: 'rgba(0,0,0,0.4)', backdropFilter: 'blur(2px)' }}
+        onClick={onToggle}
+      />
+
       <div
         ref={panelRef}
-        className={`feedback-panel fixed right-0 top-0 z-50 h-full p-3 transition-transform duration-300 ease-out ${
+        className={`feedback-panel fixed right-0 top-0 z-50 h-full p-3 transition-transform duration-[250ms] ease-[cubic-bezier(0.32,0.72,0,1)] ${
           isOpen ? 'translate-x-0' : 'translate-x-full'
         }`}
       >

--- a/packages/widget/src/client/styles.css
+++ b/packages/widget/src/client/styles.css
@@ -44,6 +44,8 @@
   --color-accent-foreground: #e8eaed;
   --color-destructive: #ef4444;
 
+  --spring: cubic-bezier(0.32, 0.72, 0, 1);
+
   color-scheme: dark;
   font-family: 'Inter', system-ui, -apple-system, sans-serif;
   letter-spacing: -0.011em;


### PR DESCRIPTION
## Summary

- Adds a semi-transparent backdrop overlay (`rgba(0,0,0,0.4)` + `blur(2px)`) behind the feedback panel that smoothly fades in when the panel opens and fades out on close (z-40, panel stays z-50)
- Updates panel slide transition from `duration-300 ease-out` to `duration-[250ms] ease-[cubic-bezier(0.32,0.72,0,1)]` for an iOS-style spring feel
- Adds `--spring` CSS variable to `.feedback-panel` for future reuse
- Backdrop uses the `feedback-panel` class for CSS scope isolation and triggers `onToggle` on click (complementary to the existing mousedown listener)

Closes #33

## Test plan
- [ ] Open the feedback panel — backdrop fades in smoothly behind the panel
- [ ] Close via X button / Escape / clicking backdrop — backdrop fades out
- [ ] Panel slide animation feels snappier with the spring easing
- [ ] Trigger bar is not affected by the backdrop (trigger bar is z-50)
- [ ] Existing click-outside (mousedown) handler still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a semi-transparent, blurred backdrop overlay that appears when the feedback panel is open. Clicking the backdrop closes the panel, providing an additional way for users to dismiss the panel and improving the overall interaction experience.

* **Style**
  * Enhanced animation transitions with optimized timing and a refined spring-like easing curve for smoother panel movements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->